### PR TITLE
enable multiple testing environments in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: python
 
-python: 3.5
-env:
-  - TOXENV=py27
-  - TOXENV=py35
-  - TOXENV=py36
+matrix:
+  include:
+  - python: 2.7
+    env: TOXENV=py27
+  - python: 3.5
+    env: TOXENV=py35
+  - python: 3.6
+    env: TOXENV=py36
 
 install:
   - pip install -U tox


### PR DESCRIPTION
 - [x] closes #64
 - [ ] tests added / passed

rewrites .travis.yml to include multiple python environments in the build matrix